### PR TITLE
Chored: remove default value for autoCapitalize of TextInput

### DIFF
--- a/lib/src/components/TextInput.re
+++ b/lib/src/components/TextInput.re
@@ -93,7 +93,6 @@ let make =
   let autoCapitalize_ =
     autoCapitalize
     ->Belt.Option.flatMap(autoCapitalizeFromJs)
-    ->Belt.Option.getWithDefault(`sentences);
 
   let handleFocus =
     React.useCallback2(
@@ -149,7 +148,7 @@ let make =
         testID
         placeholder=placeholder_
         keyboardType=keyboardType_
-        autoCapitalize=autoCapitalize_
+        autoCapitalize=?autoCapitalize_
         ?defaultValue
         ?value
         onChange

--- a/lib/src/components/__tests__/__snapshots__/MentionTextInput.test.js.snap
+++ b/lib/src/components/__tests__/__snapshots__/MentionTextInput.test.js.snap
@@ -58,7 +58,6 @@ exports[`MentionTextInput Snapshot renders correctly 1`] = `
         >
           <TextInput
             allowFontScaling={true}
-            autoCapitalize="sentences"
             autoCorrect={true}
             autoFocus={false}
             editable={true}
@@ -191,7 +190,6 @@ exports[`MentionTextInput Snapshot renders correctly 2`] = `
         >
           <TextInput
             allowFontScaling={true}
-            autoCapitalize="sentences"
             autoCorrect={true}
             autoFocus={false}
             editable={false}

--- a/lib/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/lib/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -34,7 +34,6 @@ exports[`TextInput renders correctly 1`] = `
   >
     <TextInput
       allowFontScaling={true}
-      autoCapitalize="sentences"
       autoCorrect={false}
       autoFocus={false}
       editable={true}
@@ -124,7 +123,6 @@ exports[`TextInput renders correctly 2`] = `
   >
     <TextInput
       allowFontScaling={true}
-      autoCapitalize="sentences"
       autoCorrect={false}
       autoFocus={false}
       editable={true}
@@ -214,7 +212,6 @@ exports[`TextInput renders correctly 3`] = `
   >
     <TextInput
       allowFontScaling={true}
-      autoCapitalize="sentences"
       autoCorrect={false}
       autoFocus={false}
       editable={true}
@@ -341,7 +338,6 @@ exports[`TextInput renders correctly 4`] = `
   >
     <TextInput
       allowFontScaling={true}
-      autoCapitalize="sentences"
       autoCorrect={false}
       autoFocus={false}
       editable={false}
@@ -468,7 +464,6 @@ exports[`TextInput renders correctly 5`] = `
   >
     <TextInput
       allowFontScaling={true}
-      autoCapitalize="sentences"
       autoCorrect={false}
       autoFocus={false}
       editable={false}


### PR DESCRIPTION
# Summary:
- If we add the default value for autoCapitalize props of TextInput. It leads to change a lot of snapshots when we apply it on the mobile app. So this PR will remove it, it not affect TextInput that used on the mobile app.