### PR TITLE
fix: dynamic mode date|time instead of fixed date

### DIFF
--- a/documentation/components/DateTimePicker.mdx
+++ b/documentation/components/DateTimePicker.mdx
@@ -12,7 +12,7 @@ import { DateTimePicker } from 'rn-hero-design'
 
 <Props props_={{
   show: { type: 'Boolean', required: false, defaultValue: { value: 'false' } },
-  mode: { type: '"date" | "datetime"', required: false, defaultValue: { value: '"date"' } },
+  mode: { type: '"date" | "time"', required: false, defaultValue: { value: '"date"' } },
   value: { type: 'DateObject', required: false, defaultValue: { value: 'new Date()' } },
   onChange: { type: 'DateObject => void', required: false },
   onDismiss: { type: 'void => void', required: false },

--- a/lib/src/bindings/RNCDateTimePicker.re
+++ b/lib/src/bindings/RNCDateTimePicker.re
@@ -12,7 +12,7 @@ type changeEvent = ChangeEvent.t;
 external make:
   (
     ~testID: string=?,
-    ~mode: [@bs.string] [ | `date | `time]=?,
+    ~mode: [ | `date | `time]=?,
     ~display: [@bs.string] [
                 | `default
                 | `spinner

--- a/lib/src/components/DateTimePicker.re
+++ b/lib/src/components/DateTimePicker.re
@@ -101,12 +101,13 @@ let make =
     (
       ~show=false,
       ~value: Js.Date.t=Js.Date.make(),
+      ~mode=`date,
       ~onChange=noop,
       ~onDismiss=noop,
       ~theme=Hero_Theme.default,
     ) =>
   Helpers.Platform.isAndroid
-    ? <DateTimePickerAndroid show mode=`date value onChange onDismiss />
-    : <DateTimePickerIOS show mode=`date value onChange onDismiss theme />;
+    ? <DateTimePickerAndroid show mode value onChange onDismiss />
+    : <DateTimePickerIOS show mode value onChange onDismiss theme />;
 
 let default = Helpers.injectTheme(make);


### PR DESCRIPTION
Changed datetimepicker behavior to be dynamic mode date|time instead of fixed date
This changes required to complete this PR https://github.com/Thinkei/eh-mobile-pro/pull/2835