### PR TITLE
Chore: Fix calendar typing

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-hero-design",
-  "version": "3.4.1-beta.3",
+  "version": "3.4.1-beta.4",
   "description": "",
   "main": "lib.js",
   "types": "./dist/src/index.d.ts",

--- a/lib/src/components/Calendar.gen.tsx
+++ b/lib/src/components/Calendar.gen.tsx
@@ -11,17 +11,15 @@ import {Event_pressEvent as ReactNative_Event_pressEvent} from '../../src/shims/
 
 import {Style_t as ReactNative_Style_t} from '../../src/shims/ReactNative.shim';
 
-// tslint:disable-next-line:max-classes-per-file 
-// tslint:disable-next-line:class-name
-export abstract class markedDate { protected opaque!: any }; /* simulate opaque types */
-
 // tslint:disable-next-line:interface-over-type-literal
-export type markedDates = markedDate[];
+export type color = string;
+
+export interface ImarkedDate { readonly date: Date; readonly colors: color[] };
 
 // tslint:disable-next-line:interface-over-type-literal
 export type Props = {
   readonly currentView?: Date; 
-  readonly markedDates?: markedDates; 
+  readonly markedDates?: ImarkedDate[]; 
   readonly maxDate?: Date; 
   readonly minDate?: Date; 
   readonly onChange?: (_1:Date) => void; 
@@ -293,7 +291,7 @@ export type Props = {
 
 export const make: React.ComponentType<{
   readonly currentView?: Date; 
-  readonly markedDates?: markedDates; 
+  readonly markedDates?: ImarkedDate[]; 
   readonly maxDate?: Date; 
   readonly minDate?: Date; 
   readonly onChange?: (_1:Date) => void; 
@@ -566,7 +564,7 @@ export const make: React.ComponentType<{
 // tslint:disable-next-line:interface-over-type-literal
 export type $$default_Props = {
   readonly currentView?: Date; 
-  readonly markedDates?: markedDates; 
+  readonly markedDates?: ImarkedDate[]; 
   readonly maxDate?: Date; 
   readonly minDate?: Date; 
   readonly onChange?: (_1:Date) => void; 
@@ -838,7 +836,7 @@ export type $$default_Props = {
 
 export const $$default: React.ComponentType<{
   readonly currentView?: Date; 
-  readonly markedDates?: markedDates; 
+  readonly markedDates?: ImarkedDate[]; 
   readonly maxDate?: Date; 
   readonly minDate?: Date; 
   readonly onChange?: (_1:Date) => void; 

--- a/lib/src/components/Calendar.re
+++ b/lib/src/components/Calendar.re
@@ -41,13 +41,10 @@ let hasVisibleDate = dates => dates |> Js.Array.some(Belt.Option.isSome);
 type color = string;
 
 [@genType]
-[@bs.deriving abstract]
 type markedDate = {
   date: Js.Date.t,
   colors: array(color),
 };
-
-type markedDates = array(markedDate);
 
 type parsedMarkedDates = Js.Dict.t(array(color));
 
@@ -63,7 +60,7 @@ let make =
       ~onPressNext=noop,
       ~onPressTitle=noop,
       ~theme=Hero_Theme.default,
-      ~markedDates: markedDates=[||],
+      ~markedDates: array(markedDate)=[||],
       ~minDate: option(Js.Date.t)=?,
       ~maxDate: option(Js.Date.t)=?,
     ) => {
@@ -150,16 +147,16 @@ let make =
     markedDates->Belt.Array.reduce(
       Js.Dict.empty(),
       (parsedMarkedDates, mark) => {
-        let markedDateString = Js.Date.toDateString(dateGet(mark));
+        let markedDateString = Js.Date.toDateString(mark.date);
 
         switch (parsedMarkedDates->Js.Dict.get(markedDateString)) {
         | None =>
-          parsedMarkedDates->Js.Dict.set(markedDateString, colorsGet(mark));
+          parsedMarkedDates->Js.Dict.set(markedDateString, mark.colors);
           parsedMarkedDates;
         | Some(colors) =>
           parsedMarkedDates->Js.Dict.set(
             markedDateString,
-            Array.concat([colors, colorsGet(mark)]),
+            Array.concat([colors, mark.colors]),
           );
           parsedMarkedDates;
         };

--- a/lib/src/shims/ReactNative.shim.ts
+++ b/lib/src/shims/ReactNative.shim.ts
@@ -10,10 +10,9 @@ import {
   ImageStyle,
 } from 'react-native';
 
-export type Style_t =
-  | StyleProp<ViewStyle>
-  | StyleProp<TextStyle>
-  | StyleProp<ImageStyle>;
+export type Style_t = StyleProp<ViewStyle> &
+  StyleProp<TextStyle> &
+  StyleProp<ImageStyle>;
 export type Color_t = string;
 export type Event_pressEvent = () => void;
 


### PR DESCRIPTION
remove [js abstract] because it not expose properties to external 